### PR TITLE
Fixed shade overlay under floating windows

### DIFF
--- a/lua/shade.lua
+++ b/lua/shade.lua
@@ -105,6 +105,7 @@ local function filter_wininfo(wininfo)
     col    = wininfo.wincol - 1,
     width  = wininfo.width,
     height = wininfo.height,
+    zindex = 1,
   }
 end
 


### PR DESCRIPTION
See:
https://github.com/NvChad/NvChad/issues/1696
https://github.com/sunjon/Shade.nvim/issues/37

z-index 1 allows overlays to be drawn on top of regular buffers but under floating ones like mason etc.